### PR TITLE
Adds sanity check on addresses in ClayDistributor constructor

### DIFF
--- a/contracts/ClayDistributor.sol
+++ b/contracts/ClayDistributor.sol
@@ -14,6 +14,7 @@ contract ClayDistributor {
     mapping(address => bool) public isClaimed;
 
     constructor(address token_, bytes32 merkleRoot_, uint256 dropAmount_) {
+        require(token_ != address(0), "ClayDistributor: ZERO_ADDRESS");
         token = token_;
         merkleRoot = merkleRoot_;
         dropAmount = dropAmount_;

--- a/test/005_clay_distributor_test.js
+++ b/test/005_clay_distributor_test.js
@@ -53,6 +53,13 @@ describe("Clay Distributor", function () {
         DistributorAddress = clayDistributor.address;
     });
 
+    it("should fail to deploy a clay distributer contract with zero address for airdrop token", async () => {
+        
+        const ClayDistributor = await hre.ethers.getContractFactory('ClayDistributor')
+
+        await expect(ClayDistributor.deploy(ethers.constants.AddressZero, root, dropAmountInWei)).to.be.revertedWith("ClayDistributor: ZERO_ADDRESS");
+    })
+
     it('Mints 300 CLAY to Distributor', async function () {
         const amount = ethers.utils.parseUnits('300.0', 'ether')
         expect(await clayToken.balanceOf(DistributorAddress)).to.equal(0)


### PR DESCRIPTION
Fix for _Recommendation-4 (Undetermined) Add Sanity Address Checks in Constructor_ from Audit Report.