### PR TITLE
fixes ownership transfer test

### DIFF
--- a/tasks/emp-mint.js
+++ b/tasks/emp-mint.js
@@ -127,6 +127,7 @@ task("emp-mint", "Mint the EMP")
             } catch (error) {
                 console.log(colors.red("\n Minting EMP failed: ....."));
                 console.log(error)
+                throw error
             }
         }
     );

--- a/test/006_emp_ownership.test.js
+++ b/test/006_emp_ownership.test.js
@@ -79,11 +79,11 @@ describe("ExpiringMultiParty Contract", function () {
 
     it("should not be able to mint a position on emp after shutdown", async () => {
 
-        expect(await hre.run('emp-mint', {
+        await expect(hre.run('emp-mint', {
             empAddress: expiringMultiPartyAddress,
             collateralAmount: '800',
             additionalCollateralRatio: '0.25',
-        })).to.throw
+        })).to.be.revertedWith("Only callable pre-expiry")
 
     })
 


### PR DESCRIPTION
The emp mint was just logging the error in console. The test case should have been failing but it was passing.
Now have added a line in emp-mint task to throw the error generated and did necessary changes in test case.